### PR TITLE
Adding site_name to supported metas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nuxt social meta
 
-Nuxt.js module generate meta-tags for social network - facebook and twitter.
+Nuxt.js module generate meta-tags for social network - Facebook, Twitter, and LinkedIn.
 
 ## Install
 
@@ -15,16 +15,19 @@ Add module to nuxt.config.js
 ```js
 module.exports = {
   modules: [
-    ...
-    ['nuxt-social-meta', {
-      url: 'Site url',
-      title: 'Title site',
-      description: 'Description site',
-      img: 'Link to image in static folder',
-      locale: 'ru_RU',
-      twitter: '@UserName',
-      themeColor: '#ThemeColor'
-    }]
-  ]
+    ...[
+      'nuxt-social-meta',
+      {
+        url: 'Site url',
+        title: 'Title site',
+        site_name: 'Site Name',
+        description: 'Description site',
+        img: 'Link to image in static folder',
+        locale: 'ru_RU',
+        twitter: '@UserName',
+        themeColor: '#ThemeColor',
+      },
+    ],
+  ],
 }
 ```

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
-module.exports = function socialMeta (options) {
-  
+module.exports = function socialMeta(options) {
   // options.url
   // options.title
   // options.description
@@ -15,20 +14,21 @@ module.exports = function socialMeta (options) {
     { name: 'publisher', content: options.url },
     { name: 'apple-mobile-web-app-title', content: options.title },
     { name: 'theme-color', content: options.themeColor },
-    // Fb
+    // Fb & LinkedIn
     { name: 'og:title', content: options.title },
     { name: 'og:description', content: options.description },
     { name: 'og:type', content: 'website' },
     { name: 'og:url', content: options.url },
     { name: 'og:image', content: options.img },
     { name: 'og:locale', content: options.locale },
+    { name: 'og:site_name', content: options.site_name },
     // Twitter
     { name: 'twitter:card', content: 'summary_large_image' },
     { name: 'twitter:site', content: options.twitter },
     { name: 'twitter:creator', content: options.twitter },
     { name: 'twitter:title', content: options.title },
     { name: 'twitter:description', content: options.description },
-    { name: 'twitter:image', content: options.img }
+    { name: 'twitter:image', content: options.img },
   ]
 
   // Add meta tags to head
@@ -37,11 +37,10 @@ module.exports = function socialMeta (options) {
       this.options.head.meta.push({
         hid: tag.name,
         name: tag.name,
-        content: tag.content
+        content: tag.content,
       })
     }
   })
-
 }
 
 module.exports.meta = require('./package.json')

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-social-meta",
   "version": "0.0.1",
-  "description": "Nuxt.js module generate meta-tags for social network - facebook and twitter.",
+  "description": "Nuxt.js module generate meta-tags for social network - Facebook, Twitter, and LinkedIn.",
   "license": "MIT",
   "repository": "https://github.com/AlekseyPleshkov/nuxt-social-meta",
   "publishConfig": {


### PR DESCRIPTION
LinkedIn uses the meta site_name when displaying cards for websites. This fork adds support for the site_name meta.