### PR TITLE
fix - og tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,13 +8,13 @@ module.exports = function socialMeta(options) {
     { name: "theme-color", content: options.themeColor },
 
     // Facebook & LinkedIn
-    { name: "og:title", content: options.title },
-    { name: "og:description", content: options.description },
-    { name: "og:type", content: "website" },
-    { name: "og:url", content: options.url },
-    { name: "og:image", content: options.img },
-    { name: "og:locale", content: options.locale },
-    { name: "og:site_name", content: options.site_name },
+    { property: "og:title", content: options.title },
+    { property: "og:description", content: options.description },
+    { property: "og:type", content: "website" },
+    { property: "og:url", content: options.url },
+    { property: "og:image", content: options.img },
+    { property: "og:locale", content: options.locale },
+    { property: "og:site_name", content: options.site_name },
 
     // Twitter
     { name: "twitter:card", content: options.twitter_card },


### PR DESCRIPTION
According to the Facebook developer site, the of tags should have the key as property and not as the name.
closes #5